### PR TITLE
Fixed wrong project name and copyright from headers.

### DIFF
--- a/DVCustomizer/DVCustomizerSDK/DVCategories/NSString+DVUtils.h
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/NSString+DVUtils.h
@@ -1,9 +1,9 @@
 //
 //  NSString+DVUtils.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/NSString+DVUtils.m
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/NSString+DVUtils.m
@@ -1,9 +1,9 @@
 //
 //  NSString+DVUtils.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "NSString+DVUtils.h"

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIColor+DVUtils.h
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIColor+DVUtils.h
@@ -1,9 +1,9 @@
 //
 //  UIColor+DVUtils.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIColor+DVUtils.m
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIColor+DVUtils.m
@@ -1,9 +1,9 @@
 //
 //  UIColor+DVUtils.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "UIColor+DVUtils.h"

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIImage+DVUtils.h
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIImage+DVUtils.h
@@ -1,9 +1,9 @@
 //
 //  UIImage+DVUtils.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIImage+DVUtils.m
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIImage+DVUtils.m
@@ -1,9 +1,9 @@
 //
 //  UIImage+DVUtils.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "UIImage+DVUtils.h"

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIView+DVView.h
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIView+DVView.h
@@ -1,9 +1,9 @@
 //
 //  UIView+DVView.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/6/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/DVCustomizer/DVCustomizerSDK/DVCategories/UIView+DVView.m
+++ b/DVCustomizer/DVCustomizerSDK/DVCategories/UIView+DVView.m
@@ -1,9 +1,9 @@
 //
 //  UIView+DVView.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/6/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "UIView+DVView.h"

--- a/DVCustomizer/DVCustomizerSDK/DVCustomizer.h
+++ b/DVCustomizer/DVCustomizerSDK/DVCustomizer.h
@@ -1,9 +1,9 @@
 //
 //  DVCustomizer.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/DVCustomizer/DVCustomizerSDK/DVCustomizer.m
+++ b/DVCustomizer/DVCustomizerSDK/DVCustomizer.m
@@ -1,9 +1,9 @@
 //
 //  DVCustomizer.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/2/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "DVCustomizer.h"

--- a/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVComponentEditionViewController.h
+++ b/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVComponentEditionViewController.h
@@ -1,9 +1,9 @@
 //
 //  DVComponentEditionViewController.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/3/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVComponentEditionViewController.m
+++ b/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVComponentEditionViewController.m
@@ -1,9 +1,9 @@
 //
 //  DVComponentEditionViewController.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/3/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "DVComponentEditionViewController.h"

--- a/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVSettingsViewController.h
+++ b/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVSettingsViewController.h
@@ -1,9 +1,9 @@
 //
 //  DVSettingsViewController.h
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/3/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVSettingsViewController.m
+++ b/DVCustomizer/DVCustomizerSDK/DVDictionaryEdition/DVSettingsViewController.m
@@ -1,9 +1,9 @@
 //
 //  DVSettingsViewController.m
-//  Timetracker iOS
+//  RedPool Demo App
 //
 //  Created by José Daniel Vásquez Gómez on 9/3/14.
-//  Copyright (c) 2014 Log(n). All rights reserved.
+//  Copyright (c) 2014 RedPool. All rights reserved.
 //
 
 #import "DVSettingsViewController.h"


### PR DESCRIPTION
Changed all instances of `Log(n)` to `RedPool` and `Timetracker iOS` to `RedPool Demo App`

Signed-off-by: Esteban Torres me@estebantorr.es
